### PR TITLE
docs: add Related Resources section (ARC Raider Hub companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Contributions are welcome! If you find bugs or have suggestions:
 2. Submit a pull request
 3. Report data inconsistencies
 
+## Related Resources
+
+- [ARC Raider Hub](https://arcraiderhub.xyz/) — ARC Raiders weapon tier lists, extraction routes, augment guides, and raid strategies.
+
 ## License
 
 MIT License - See [LICENSE](LICENSE) for details


### PR DESCRIPTION
Thanks for building RaiderCache — a searchable loot tier tool is a great companion to a broader guide hub.

This PR adds a small `## Related Resources` section pointing to a companion player-facing guide site:

- [ARC Raider Hub](https://arcraiderhub.xyz/) — ARC Raiders weapon tier lists, extraction routes, augment guides, and raid strategies.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `before:## License`.)_